### PR TITLE
+ APY500 Yaesu FTM-500DE

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -117,6 +117,11 @@ mice:
    model: FTM-400DR
    class: rig
 
+ - suffix: "_4"
+   vendor: Yaesu
+   model: FTM-500DE
+   class: rig
+
  - suffix: "(5"
    vendor: Anytone
    model: D578UV
@@ -1343,6 +1348,11 @@ tocalls:
  - tocall: APY400
    vendor: Yaesu
    model: FTM-400
+   class: rig
+
+ - tocall: APY500
+   vendor: Yaesu
+   model: FTM-500
    class: rig
    
  - tocall: APYS??


### PR DESCRIPTION
Hello Hessu (OH7LZB),

I've created one thread in [groups.io/APRS/Yaesu FTM-500DE APRS BEACON STATUS TXT](https://groups.io/g/APRS/topic/yaesu_ftm_500de_aprs_beacon/101247433?p=,,,20,0,0,0::recentpostdate/sticky,,,20,2,0,101247433,previd%3D1694873280342113799,nextid%3D1692319723371366629&previd=1694873280342113799&nextid=1692319723371366629) and later, when I found out the official group for APRS.fi, another thread [gorups.google.com/aprsfi/Suffixed _4 on BEACON STATUSTXT (FTM-500DE)](https://groups.google.com/g/aprsfi/c/zG5ABuxkxxw).

I also went though the notes on [README.md](https://github.com/anxanywhere/aprs-deviceid/blob/main/README.md) and [ALLOCATING.md](https://github.com/anxanywhere/aprs-deviceid/blob/main/ALLOCATING.md). I'm definitively neither hardware vendor or app APRS owner. I'm just someone that owns the Yaesu FTM-500DE that is absolutely annoyed to see my entries on aprs.fi being suffixed by _4.