### PR TITLE
classes: Added missing "gadget", "network", "daemon" classes in tocalls.yaml

### DIFF
--- a/ALLOCATING.md
+++ b/ALLOCATING.md
@@ -190,7 +190,7 @@ mandatory - if a suitable class is not available, it can be omitted.
  * tracker: Small APRS tracker device
    - Typically devices with a GNSS receiver (GPS), primarily reporting a
      moving position.
- * gadget: Small APRS non-tracker device
+ * gadget: Small non-tracker APRS device
    - Portable or fixed devices
    - Typically embedded devices without a GNSS receiver, reporting telemetry
      or otherwise not fitting the tracker category.
@@ -208,14 +208,11 @@ mandatory - if a suitable class is not available, it can be omitted.
  * service: APRS network service: web services, APRS message bots
    - Software not typically installed by users, primarily available as
      a service for users on the APRS network, or on the web for
-     accessing APRS.
+     accessing APRS. APRS message bots, SMS gateways and hosted services.
  * wx: Weather station
    - A dedicated weather station.
  * satellite: Satellite-based station
    - APRS software running on the satellite itself.
- * service: Software running as a service
-   - Web services
-   - Message gateways (SMS, etc)
 
 
 Operating systems

--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -26,6 +26,10 @@ classes:
    shown: Tracker
    description: Tracker device
  
+ - class: gadget
+   shown: Gadget
+   description: Small non-tracker APRS device
+
  - class: rig
    shown: Rig
    description: Mobile or desktop radio
@@ -39,8 +43,20 @@ classes:
    description: Mobile phone or tablet app
  
  - class: software
-   shown: Software
+   shown: Desktop software
    description: Desktop software
+
+ - class: daemon
+   shown: Background software
+   description: Computer software without user interface
+
+ - class: service
+   shown: Service
+   description: Software running as a web service or a message bot
+
+ - class: network
+   shown: APRS network hardware appliance
+   description: A hardware appliance with self-contained APRS networking features
 
  - class: digi
    shown: Digipeater
@@ -57,10 +73,6 @@ classes:
  - class: satellite
    shown: Satellite
    description: Satellite-based station
-
- - class: service
-   shown: Service
-   description: Software running as a web service
 
 #
 # mic-e device identifier index for new-style 2-character device


### PR DESCRIPTION
These were defined in ALLOCATING.md but not added in tocalls.yaml.

Also clarified "service" definition and removed duplicate "service" in ALLOCATING doc.