### PR TITLE
mic-e: + SainSonic AP510

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -173,6 +173,11 @@ mice:
    model: VP-Tracker
    class: tracker
 
+ - suffix: " X"
+   vendor: SainSonic
+   model: AP510
+   class: tracker
+
 #
 # mic-e legacy devices, with an unique comment suffix and prefix
 #


### PR DESCRIPTION
As documented in http://www.aprs.org/aprs12/mic-e-types.txt, this defines the mic-e device id for the SainSonic AP510. I've no idea why my callsign is attributed to it on aprs.org, but now I feel obligated to add it here. The author is BH7NOR.

Earlier firmwares send `_X`. Not sure if that is worth adding as well.