### PR TITLE
+ APRPJU for Piju, 9M2PJU

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -1484,8 +1484,8 @@ tocalls:
    os: ipad
 
  - tocall: APRPJU
-   vendor: Piju 9M2PJU
-   model: 9M2PJU Bot
+   vendor: Piju, 9M2PJU
+   model: 9M2PJU APRS Bot
    class: daemon
    contact: 9m2pju@hamradio.my
    features:


### PR DESCRIPTION
Rename from 9M2PJU Bot to 9M2PJU APRS Bot and typo fix.