### PR TITLE
Add APZAAC tocall for Advanced APRS Chat

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -1966,6 +1966,17 @@ tocalls:
    model: UPRS
    vendor: NR0Q
 
+ - tocall: APZAAC
+   vendor: LB5ZH
+   model: Advanced APRS Chat
+   class: app
+   os: Windows, macOS, Linux
+   features:
+     - messaging
+     - item
+     - object
+     - map
+
  - tocall: APZG??
    vendor: OH2GVE
    model: aprsg


### PR DESCRIPTION
## Summary
Adding device ID registration for Advanced APRS Chat (APZAAC).

## Details
- **Tocall**: APZAAC (in experimental APZ* range)
- **Vendor**: LB5ZH
- **Model**: Advanced APRS Chat
- **Class**: app
- **OS**: Windows, macOS, Linux
- **Features**: messaging, item, object, map

Advanced APRS Chat is a cross-platform desktop application for APRS messaging with support for maps and object/item reporting.