### PR TITLE
chore: allow for multiple Graywolf TOCALLs

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -741,7 +741,7 @@ tocalls:
    model: APRS-Go
    class: app
 
- - tocall: APGRWO
+ - tocall: APGRW?
    vendor: Chris Snell, NW5W
    model: NW5W Graywolf
    class: software


### PR DESCRIPTION
I'm about to launch an Android version of Graywolf (open source APRS stack).  I want to use a different TOCALL for this, so I'm requesting a regex `APGRW?` modification.

Thanks!