### PR TITLE
Add new TOCALL APRW for DD5RW Tracker & Bidirectional iGate

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -2415,3 +2415,9 @@ tocalls:
    model: PSKmail
    class: software
 
+ - tocall: APRW??
+   vendor: Ralph (DD5RW)
+   model: Dynamic Mobile Multi-Band Tracker & Bidirectional iGate
+   class: igate
+   os: Linux/Unix
+


### PR DESCRIPTION
Hello everyone,

I would like to request the addition of a new TOCALL (APRW) to the tocalls.yaml for my custom APRS project.

About the project:
It is a highly customized Python-based software running on a Raspberry Pi 4. While it acts as a dynamic smart tracker for my mobile station (adjusting beacon rates based on GPS speed and turn angles), its main feature is acting as a Bidirectional iGate. It performs RX/TX cross-gating, dynamically filtering internet traffic (APRS-IS) based on the current GPS radius and routing it to local RF stations. It supports multi-band operations using both ESP32-LoRa and Digirig (VHF/UHF).

Since its primary network impact is bridging the gap between RF and APRS-IS for the local community, I have set the class to igate and the OS to Linux/Unix.